### PR TITLE
Stretcher Missing Texture

### DIFF
--- a/mdl/ascii/placeables/new/various/plc_strcrmc2.mdl
+++ b/mdl/ascii/placeables/new/various/plc_strcrmc2.mdl
@@ -26,7 +26,7 @@ node trimesh peg_01
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 34
      0.00000  0.00000 -0.00215
@@ -314,7 +314,7 @@ node trimesh leg1
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 16
     -0.01500 -0.39238 -0.01179
@@ -388,7 +388,7 @@ node trimesh leg2
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 16
     -0.01500 -0.39238 -0.01179
@@ -462,7 +462,7 @@ node trimesh peg_02
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 34
      0.00000  0.00000 -0.00210
@@ -892,7 +892,7 @@ node trimesh peg_03
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 34
      0.00000  0.00000 -0.00210
@@ -1484,7 +1484,7 @@ node trimesh side_slat
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 204
      0.02856  0.65506 -0.01062
@@ -2791,7 +2791,7 @@ node trimesh side_slat01
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 209
      0.02856  0.65506 -0.01062
@@ -3615,7 +3615,7 @@ node trimesh leg04
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 16
      0.01500  0.39238  0.01179
@@ -3689,7 +3689,7 @@ node trimesh leg3
   ambient 0.00 0.00 0.00
   diffuse 0.59 0.59 0.59
   specular 0.00 0.00 0.00
-  bitmap plc_wood2
+  bitmap tcm01_wood02
   shininess 10
   verts 16
      0.01500  0.39238  0.01179


### PR DESCRIPTION
Fixes the stretcher placeable's missing wood texture. At the moment, it is using an unexistent texture, so in-game the whole thing looks white.