### PR TITLE
feature/nui-folder-jpeg

### DIFF
--- a/textures/lossy_keep/jpg/nui/map_surface.jpg
+++ b/textures/lossy_keep/jpg/nui/map_surface.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f69eec7c5723d64eaee7e6cb4d7c8e6ef34c6c00eb31f3d3fd2ec74d7e1f27
+size 362829


### PR DESCRIPTION
New folder structure for jpeg nui images

New nui folder inside: lossy_keep\jpg\ see below:
textures\lossy_keep\jpg\nui