### PR TITLE
Campfire Noclip

### DIFF
--- a/static/walkmesh/placeables/override/ours/plc_i06.pwk
+++ b/static/walkmesh/placeables/override/ours/plc_i06.pwk
@@ -1,0 +1,12 @@
+# NeverBlender 4.0.2|Blender 4.0.0|2024-09-02
+filedependancy unknown
+newmodel I06_pwk_use01
+setsupermodel I06_pwk_use01 null
+classification CHARACTER
+setanimationscale 1.0
+beginmodelgeom I06_pwk_use01
+node dummy I06_pwk_use01
+  parent null
+endnode
+endmodelgeom I06_pwk_use01
+donemodel I06_pwk_use01


### PR DESCRIPTION
Removes the hitbox from the small campfire model.

![Image](https://github.com/user-attachments/assets/1470a530-ec8c-42d6-bac6-36ecfeba3263)