### PR TITLE
Desert Cave Textures

### DIFF
--- a/textures/lossy_keep/dds/placeables/various/tw002_rock02.dds
+++ b/textures/lossy_keep/dds/placeables/various/tw002_rock02.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d67b952eb41eb9c04cb6e25468d912711ef1c859e60fd9f72bfd362b221b2f6
+size 174796

--- a/textures/lossy_keep/dds/placeables/various/tw002_rock03.dds
+++ b/textures/lossy_keep/dds/placeables/various/tw002_rock03.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb6f3be3127f4e37e82d0008b738caab6b9c200c46cc26f44b39c0ab6027a91c
+size 174796

--- a/textures/lossy_keep/dds/placeables/various/tw002_rockwat.dds
+++ b/textures/lossy_keep/dds/placeables/various/tw002_rockwat.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1b54082da84e8019b33ae835624f6de6597ced84e5c3bf791b7edbfc6f57973
+size 349572

--- a/textures/lossy_keep/dds/placeables/various/tw002_testa.dds
+++ b/textures/lossy_keep/dds/placeables/various/tw002_testa.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24cb3a859683cc44e3d64e9714f163e5f70a8f42a1e6d3803ca3ff853fa5423c
+size 349572

--- a/textures/lossy_keep/dds/placeables/various/tw002_testc.dds
+++ b/textures/lossy_keep/dds/placeables/various/tw002_testc.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4861961ce72e70d1bff2729fbf6a51b758dd7aeef1f6e6fe59bd5fba88d6e2f9
+size 87460

--- a/textures/lossy_keep/tga/placeables/various/tw002_crystal0r.tga
+++ b/textures/lossy_keep/tga/placeables/various/tw002_crystal0r.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c62d8f82088bf056a7fd10d1a2f4b3f34c738270053d7611a5cd3ff621f60c8
+size 65554

--- a/textures/lossy_keep/tga/placeables/various/tw002_hrdwd01.tga
+++ b/textures/lossy_keep/tga/placeables/various/tw002_hrdwd01.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6881181758a04840368beddad3172ee6eb10c40e19196dd4dca9dad20f65cf9c
+size 49170

--- a/textures/lossy_keep/tga/placeables/various/tw002_rrties01.tga
+++ b/textures/lossy_keep/tga/placeables/various/tw002_rrties01.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d11a2d6c8b81f205abd7379485fbafdc3a2256729db82db75fe2c7b465dfe3a
+size 65554

--- a/textures/lossy_keep/tga/placeables/various/tw002_wood03.tga
+++ b/textures/lossy_keep/tga/placeables/various/tw002_wood03.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e422e16d216e708d238df2b4452df6bdfda7dcd0a8610a1ec19527619574da9
+size 49170


### PR DESCRIPTION
To be used as part of a texture override package replacer for Mines and Caverns tileset.

Credits:
https://neverwintervault.org/project/nwn1/hakpak/tileset/desert-mines