### PR TITLE
Rural Tileset Fix

### DIFF
--- a/static/set/override/zwerks/rural/ttr01.set
+++ b/static/set/override/zwerks/rural/ttr01.set
@@ -7731,7 +7731,7 @@ Orientation=0
 ImageMap2D=micn01_W03
 
 [TILE250]
-Model=tcn01_x03_01
+Model=ttr01_x03_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -7787,7 +7787,7 @@ Orientation=0
 ImageMap2D=micn01_W04
 
 [TILE252]
-Model=tcn01_x04_01
+Model=ttr01_x04_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -7859,7 +7859,7 @@ Z=0.00
 Orientation=-90.0
 
 [TILE254]
-Model=tcn01_x09_01
+Model=ttr01_x09_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -7889,7 +7889,7 @@ VisibilityOrientation=0
 ImageMap2D=MICN01_X09
 
 [TILE255]
-Model=tcn01_y09_01
+Model=ttr01_y09_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -7954,7 +7954,7 @@ VisibilityOrientation=0
 ImageMap2D=micn01_W10
 
 [TILE257]
-Model=tcn01_x10_01
+Model=ttr01_x10_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -7984,7 +7984,7 @@ VisibilityOrientation=0
 ImageMap2D=MICN01_X10
 
 [TILE258]
-Model=tcn01_y10_01
+Model=ttr01_y10_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -8042,7 +8042,7 @@ Orientation=0
 ImageMap2D=micn01_W11
 
 [TILE260]
-Model=tcn01_x11_01
+Model=ttr01_x11_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0
@@ -8079,7 +8079,7 @@ Z=0.00
 Orientation=0.0
 
 [TILE261]
-Model=tcn01_y11_01
+Model=ttr01_y11_01
 WalkMesh=msb01
 TopLeft=Grass
 TopLeftHeight=0


### PR DESCRIPTION
Fixes Zwerkule's Rural Tileset facelift using City Exterior tiles for the Neutral and Good Temples as seen below:

![1](https://github.com/user-attachments/assets/9147e928-165f-4487-880f-cc26a50fca81)