### PR TITLE
Shiny Anvil Adjustment

### DIFF
--- a/static/mtr/placeables/PLC_H06.mtr
+++ b/static/mtr/placeables/PLC_H06.mtr
@@ -3,5 +3,5 @@ renderhint NormalAndSpecMapped
 
 // Textures
 texture0 anvil
-texture1 anvil_N
-texture2 anvil_S
+
+

--- a/textures/lossless/tga/placeables/override/ours/anvil.tga
+++ b/textures/lossless/tga/placeables/override/ours/anvil.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15db96a4148c29e51a499d586304071e49a740c1fc5733f05749863173683ee5
-size 3145772
+oid sha256:b3b9b1f1d847caaaf9e5af7aeb33effc3c9d302046aac3aa9243d4dcc51420ae
+size 268901

--- a/textures/lossless/tga/placeables/override/ours/anvil_N.tga
+++ b/textures/lossless/tga/placeables/override/ours/anvil_N.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa52834ecf812f59feaa9b9fd04bc36a763a1c3a68931976218b220ebe679576
-size 3145772

--- a/textures/lossless/tga/placeables/override/ours/anvil_S.tga
+++ b/textures/lossless/tga/placeables/override/ours/anvil_S.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fc44931582a87b441116a4e97a64a69d6389c6d0a67f48fce4d6fb9978812d0
-size 3145746


### PR DESCRIPTION
The shiny vanilla anvil replacer has had its normal maps removed and made unshiny. The texture size has been reduced and recoloured to resemble cast iron. The size of this update should make this model and texture weight less than 1mb or around there.