### PR TITLE
Fantasy Interiors Tileset - Path Node Improvement

### DIFF
--- a/static/set/new/various/ftsyint/wdd04.set
+++ b/static/set/new/various/ftsyint/wdd04.set
@@ -293,7 +293,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=T
 Orientation=0
 ImageMap2D=MI_wdd04_X01_01
 
@@ -1819,7 +1819,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=I
+PathNode=T
 Orientation=0
 ImageMap2D=MI_wdd04_X02_01
 
@@ -3380,7 +3380,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=T
 Orientation=0
 ImageMap2D=MI_wdd05_X01_01
 
@@ -4528,7 +4528,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=I
+PathNode=T
 Orientation=0
 ImageMap2D=MI_wdd05_X02_01
 
@@ -6285,7 +6285,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=L
 Orientation=0
 ImageMap2D=MI_wdd05_W02_01
 
@@ -6313,8 +6313,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=N
+Orientation=180
 ImageMap2D=MI_wdd05_W01_01
 
 [TILE214]
@@ -6516,7 +6516,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=L
 Orientation=0
 ImageMap2D=MI_wdd05_W02_02
 
@@ -6544,7 +6544,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=H
 Orientation=0
 ImageMap2D=MI_wdd05_W03_01
 
@@ -6572,7 +6572,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=I
 Orientation=0
 ImageMap2D=MI_wdd05_W04_01
 
@@ -10940,8 +10940,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_M02_01
 
 [TILE373]
@@ -10968,8 +10968,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_M03_01
 
 [TILE374]
@@ -11311,8 +11311,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_M02_04
 
 [TILE385DOOR0]
@@ -11402,8 +11402,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P14_01
 
 [TILE389]
@@ -11458,8 +11458,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_P11_01
 
 [TILE391]
@@ -11577,8 +11577,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P14_03
 
 [TILE395]
@@ -11717,8 +11717,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=12582912
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_M03_04
 
 [TILE400]
@@ -11976,8 +11976,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P14_03
 
 [TILE409]
@@ -12032,8 +12032,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_M03_05
 
 [TILE410DOOR0]
@@ -12067,8 +12067,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P13_02
 
 [TILE412]
@@ -12179,8 +12179,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P13_03
 
 [TILE416]
@@ -12207,8 +12207,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P12_03
 
 [TILE417]
@@ -12235,8 +12235,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_M02_05
 
 [TILE418]
@@ -12347,8 +12347,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P12_04
 
 [TILE422]
@@ -12375,8 +12375,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_P13_04
 
 [TILE423]
@@ -12844,8 +12844,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=270
 ImageMap2D=MI_wdd06_S01_13
 
 [TILE439]
@@ -12872,8 +12872,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_S01_14
 
 [TILE440]
@@ -12900,8 +12900,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_S01_15
 
 [TILE441]
@@ -13180,8 +13180,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_wdd06_S01_30
 
 [TILE451]
@@ -13292,8 +13292,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=-1
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_S01_34
 
 [TILE454DOOR0]
@@ -13495,8 +13495,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_wdd06_S01_37
 
 [TILE461DOOR0]
@@ -13747,8 +13747,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_M02_01
 
 [TILE470]
@@ -13775,8 +13775,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_M03_01
 
 [TILE471]
@@ -13859,8 +13859,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_M02_02
 
 [TILE474]
@@ -14202,8 +14202,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_M02_04
 
 [TILE485DOOR0]
@@ -14293,8 +14293,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=L
+Orientation=90
 ImageMap2D=MI_WDD01_C02_01
 
 [TILE489]
@@ -14349,8 +14349,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=L
+Orientation=90
 ImageMap2D=MI_WDD01_C02_02
 
 [TILE491]
@@ -14377,7 +14377,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
+PathNode=H
 Orientation=0
 ImageMap2D=MI_WDD01_C03_01
 
@@ -14517,8 +14517,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_P11_01
 
 [TILE497]
@@ -14944,8 +14944,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=12582912
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_M03_04
 
 [TILE512]
@@ -15903,8 +15903,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_P14_03
 
 [TILE546]
@@ -16022,8 +16022,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_M03_05
 
 [TILE549DOOR0]
@@ -16876,8 +16876,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_P13_03
 
 [TILE580]
@@ -16904,8 +16904,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_P12_03
 
 [TILE581]
@@ -16988,8 +16988,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=12582912
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_M03_06
 
 [TILE584]
@@ -17632,8 +17632,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=12582912
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=180
 ImageMap2D=MI_WDD01_P14_05
 
 [TILE607]
@@ -18087,8 +18087,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=U
+Orientation=180
 ImageMap2D=MI_WDD01_S01_08
 
 [TILE622DOOR0]
@@ -18241,8 +18241,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=I
+Orientation=270
 ImageMap2D=MI_WDD01_S01_13
 
 [TILE628]
@@ -18983,8 +18983,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=12582912
-PathNode=A
-Orientation=0
+PathNode=H
+Orientation=90
 ImageMap2D=MI_WDD01_S01_38
 
 [TILE653DOOR0]
@@ -19053,8 +19053,8 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=1
 Sounds=0
-PathNode=A
-Orientation=0
+PathNode=N
+Orientation=180
 ImageMap2D=MI_wdd05_W01_01
 
 [TILE655DOOR0]
@@ -19172,7 +19172,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=I
+PathNode=A
 Orientation=0
 ImageMap2D=MI_wdd06_M10_02
 
@@ -19340,7 +19340,7 @@ AnimLoop2=1
 AnimLoop3=1
 Doors=0
 Sounds=0
-PathNode=I
+PathNode=A
 Orientation=0
 ImageMap2D=MI_WDD01_M10_02
 


### PR DESCRIPTION
This tileset has no path node work and 600 tiles. It'd be a huge effort to update all of them, so for now all that this PR does is updating the tiles used by some dungeons with (mostly) correct path nodes. If anything, it should fix their Line of Sight issues.